### PR TITLE
Remove ExtUtils::ParseXS version bump

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,3 @@ version = 0.001
 
 [Prereqs / ConfigureRequires]
 Alien::Build::Plugin::Gather::Dino = 0
-
-[Prereqs / TestRequires]
-ExtUtils::ParseXS = 3.30


### PR DESCRIPTION
This is fixed in Alien::Build 0.82. See
<https://github.com/Perl5-Alien/Alien-Build/issues/28>,
<https://metacpan.org/changes/release/PLICEASE/Alien-Build-0.82>.

