### PR TITLE
Change from Alien::Base::Dino (inheritance) to Alien::Role::Dino (role)

### DIFF
--- a/lib/Alien/OpenJPEG.pm
+++ b/lib/Alien/OpenJPEG.pm
@@ -4,7 +4,10 @@ package Alien::OpenJPEG;
 use strict;
 use warnings;
 
-use parent qw(Alien::Base::Dino);
+use base qw( Alien::Base );
+use Role::Tiny::With qw( with );
+
+with 'Alien::Role::Dino';
 
 1;
 __END__


### PR DESCRIPTION
Alien::Base::Dino has been removed.

See <https://rt.cpan.org/Ticket/Display.html?id=123952> (SREZIC++),
<https://metacpan.org/source/PLICEASE/Alien-Role-Dino-0.04/Changes#L4>.

Fixes <https://github.com/project-renard/p5-Alien-OpenJPEG/issues/8>.
