### PR TITLE
Move Alien share deps inside the share block

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -1,12 +1,11 @@
 use alienfile;
 
-requires 'Alien::Build::Plugin::Gather::Dino';
-requires 'Alien::gmake';
-
 plugin 'PkgConfig' => 'libopenjp2';
 
 # http://www.openjpeg.org/
 share {
+	requires 'Alien::Build::Plugin::Gather::Dino';
+	requires 'Alien::gmake';
 
 	plugin Download => (
 		url => 'https://github.com/uclouvain/openjpeg/releases',


### PR DESCRIPTION
This should make for fewer dependencies for a system install.

Fixes <https://github.com/project-renard/p5-Alien-OpenJPEG/issues/10>.
